### PR TITLE
:arrow_up: Adds Django 4 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Jacob Kaplan-Moss <jacob@jacobian.org>"]
 readme = "README.rst"
 
 [tool.poetry.dependencies]
-django = "^2 || ^3"
+django = "^2 || ^3 || ^4"
 python = "^3.6"
 
 [build-system]


### PR DESCRIPTION
Tested on a client project which worked without any warnings on Django 4.0. YMMV